### PR TITLE
FileDialog filters the dropdown list to speficy the file type on Unix based operating systems

### DIFF
--- a/mae/util/Console.java
+++ b/mae/util/Console.java
@@ -237,7 +237,20 @@ public class Console extends JFrame {
    static FileDialog saveD = new FileDialog(NULL, "Save", FileDialog.SAVE);
    static File selectFile(File f, String filter, FileDialog D) {
        if (f != null && f.exists()) D.setDirectory(f.getParent()); 
-       if (filter != null) D.setFile(filter);
+       if (filter != null) {
+                D.setFile(filter); //filter for Windows
+                String[] filters = filter.replaceAll("\\*","").split(";");
+                D.setFilenameFilter(new FilenameFilter() { //filter for Unix based operating systems
+                                            @Override
+                                            public boolean accept(File dir, String name){
+                                                    for (String f: filters)
+                                                            if( name.endsWith(f) )
+                                                                    return true;
+                                                    return false;
+
+                                            }
+                                    });
+        }
        D.setVisible(true);
        String fa = D.getFile();
        if (fa == null) return null;


### PR DESCRIPTION
As mentioned  in Java Docs setFilenameFilter(FilenameFilter) methods  is not suitable for Windows. Also, setFile(String ) method is not working on Unix. To make it work on both Linux and Windows, these two methods must be implemented. 

 https://docs.oracle.com/javase/7/docs/api/java/awt/FileDialog.html#setFilenameFilter(java.io.FilenameFilter)